### PR TITLE
Fix auth persistence across navigation

### DIFF
--- a/src/components/UserProfileButton.tsx
+++ b/src/components/UserProfileButton.tsx
@@ -29,7 +29,7 @@ export function isGoogleLoginResponse(x: any): x is GoogleLoginResponse {
 }
 
 export default function UserProfileButton() {
-  const { setIdToken } = useContext(IdTokenContext);
+  const { idToken, setIdToken } = useContext(IdTokenContext);
   const ipAddr = useIpAddress();
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [signedIn, setSignedIn] = useState(false);
@@ -39,6 +39,7 @@ export default function UserProfileButton() {
   const { signIn } = useGoogleLogin({
     clientId: clientId as string, // if it's null, we won't use the hook
     responseType: 'id_token',
+    isSignedIn: idToken !== null,
     onSuccess: (res) => {
       if (!isGoogleLoginResponse(res)) return;
       setSignedIn(true);


### PR DESCRIPTION
So the ID token state was successfully preserved just by lifting it to the top of the App. Apparently, if we also [tell react-google-login](https://github.com/anthonyjgrove/react-google-login#stay-logged-in) that we're logged in when its hooks run, it can do some kind of magic to get us Google log in info. 

This doesn't persist login across reloads, so that's a reasonable discussion to continue separately. But, this should at least reduce login pain.