### PR TITLE
UI refresh & fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,12 @@ import { CssBaseline } from '@material-ui/core';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import React, { useState } from 'react';
 import useStorage from './hooks/useStorage';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect,
+} from 'react-router-dom';
 import config from './config';
 import WebSocketContext from './contexts/WebSocketContext';
 import Detail from './Detail';
@@ -50,11 +55,10 @@ function App() {
             <IdTokenContext.Provider value={idTokenContext}>
               <CssBaseline />
               <Switch>
-                <Route exact path="/">
-                  <Overview />
-                </Route>
-                <Route exact path="/robot/:id">
-                  <Detail />
+                <Route exact path="/robot/:id/:tab?" component={Detail} />
+                <Route exact path="/" component={Overview} />
+                <Route>
+                  <Redirect to="/" />
                 </Route>
               </Switch>
             </IdTokenContext.Provider>

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
   Backdrop,
 } from '@material-ui/core';
+import { Alert, AlertTitle } from '@material-ui/lab';
 import { ArrowBack, Pause, PlayArrow } from '@material-ui/icons';
 import React, { useCallback, useContext, useState } from 'react';
 import { useParams } from 'react-router';
@@ -94,10 +95,13 @@ export default function Detail() {
           </Backdrop>
         </Fade>
         <Backdrop open={authorized === false}>
-          <Typography variant="subtitle1">
-            Authorization check failed. Please sign in or use an authorized
-            client to view robot details.
-          </Typography>
+          <Box maxWidth="40em">
+            <Alert severity="error">
+              <AlertTitle>Not authorized</AlertTitle>
+              You can view this robot if you sign in with an authorized account
+              or view this page from an authorized IP address.
+            </Alert>
+          </Box>
         </Backdrop>
       </>
     );

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -5,6 +5,7 @@ import {
   CardContent,
   CircularProgress,
   Container,
+  Fade,
   IconButton,
   Tab,
   Tabs,
@@ -77,10 +78,22 @@ export default function Detail() {
   );
 
   if (!authorized) {
+    const isLoading = authorized === null;
     return (
       <>
         <NavBar title={`${namespace}`} navIcon={backIcon}></NavBar>
-        <Backdrop open={!authorized}>
+        <Fade
+          in={isLoading}
+          style={{
+            transitionDelay: isLoading ? '500ms' : '0ms',
+          }}
+          unmountOnExit
+        >
+          <Backdrop open={true}>
+            <CircularProgress />
+          </Backdrop>
+        </Fade>
+        <Backdrop open={authorized === false}>
           <Typography variant="subtitle1">
             Authorization check failed. Please sign in or use an authorized
             client to view robot details.

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -16,7 +16,7 @@ import {
 import { Alert, AlertTitle } from '@material-ui/lab';
 import { ArrowBack, Pause, PlayArrow } from '@material-ui/icons';
 import React, { useCallback, useContext, useState, ReactElement } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useHistory } from 'react-router';
 import { Link } from 'react-router-dom';
 import NavBar from './components/NavBar';
 import AppContext from './contexts/AppContext';
@@ -57,10 +57,11 @@ export function PauseButton() {
 }
 
 export default function Detail() {
-  const { id } = useParams();
-  const namespace = atob(id);
+  const params = useParams<{ id: string; tab: string | undefined }>();
+  const history = useHistory();
+  const namespace = atob(params.id);
   const { idToken } = useContext(IdTokenContext);
-  const [tabIndex, setTabIndex] = useState(0);
+  const tabIndex = params.tab ? Number.parseInt(params.tab) : 0;
   const [receivedMsg, setReceivedMsg] = useState(false);
 
   // subscribe to all messages until we receive something
@@ -142,7 +143,7 @@ export default function Detail() {
     <>
       <Tabs
         value={tabIndex}
-        onChange={(_, index) => setTabIndex(index)}
+        onChange={(_, index) => history.push(`/robot/${params.id}/${index}`)}
         style={{ flexGrow: 1 }}
       >
         <Tab label="Viz" />
@@ -156,13 +157,11 @@ export default function Detail() {
   const content = (
     <>
       <TabHider
-        key={0}
         id={0}
         index={tabIndex}
         render={(hidden) => <VizTab namespace={namespace} enabled={!hidden} />}
       />
       <TabHider
-        key={1}
         id={1}
         index={tabIndex}
         render={(hidden) => (
@@ -170,7 +169,6 @@ export default function Detail() {
         )}
       />
       <TabHider
-        key={2}
         id={2}
         index={tabIndex}
         render={(hidden) => (

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -11,6 +11,7 @@ import {
   Tabs,
   Typography,
   Backdrop,
+  LinearProgress,
 } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import { ArrowBack, Pause, PlayArrow } from '@material-ui/icons';
@@ -78,6 +79,34 @@ export default function Detail() {
     </IconButton>
   );
 
+  const loader = (
+    <Container maxWidth="md">
+      <Fade
+        in={!receivedMsg}
+        style={{ transitionDelay: !receivedMsg ? '1000ms' : '0' }}
+      >
+        <div>
+          <Box height="2em" />
+          <Card>
+            <CardContent style={{ display: 'flex', flexDirection: 'column' }}>
+              <Box>
+                <Typography variant="h5" component="h2">
+                  Waiting for data
+                </Typography>
+                <Typography variant="body1" component="h2">
+                  This robot may be offline.
+                </Typography>
+              </Box>
+              <Box marginTop={3}>
+                <LinearProgress />
+              </Box>
+            </CardContent>
+          </Card>
+        </div>
+      </Fade>
+    </Container>
+  );
+
   if (!authorized) {
     const isLoading = authorized === null;
     return (
@@ -85,9 +114,7 @@ export default function Detail() {
         <NavBar title={`${namespace}`} navIcon={backIcon}></NavBar>
         <Fade
           in={isLoading}
-          style={{
-            transitionDelay: isLoading ? '500ms' : '0ms',
-          }}
+          style={{ transitionDelay: isLoading ? '500ms' : '0ms' }}
           unmountOnExit
         >
           <Backdrop open={true}>
@@ -106,24 +133,6 @@ export default function Detail() {
       </>
     );
   }
-
-  const loader = (
-    <Container maxWidth="md">
-      <Box height="2em" />
-      <Card>
-        <CardContent style={{ display: 'flex' }}>
-          <CircularProgress
-            variant="indeterminate"
-            size={32}
-            style={{ marginRight: '1rem' }}
-          />
-          <Typography variant="h5" component="h2">
-            Waiting for data...
-          </Typography>
-        </CardContent>
-      </Card>
-    </Container>
-  );
 
   const tabs = (
     <>

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -15,7 +15,7 @@ import {
 } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import { ArrowBack, Pause, PlayArrow } from '@material-ui/icons';
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useState, ReactElement } from 'react';
 import { useParams } from 'react-router';
 import { Link } from 'react-router-dom';
 import NavBar from './components/NavBar';
@@ -28,12 +28,16 @@ import VizTab from './VizTab';
 import IdTokenContext from './contexts/IdTokenContext';
 import useAuthCheck from './hooks/useAuthCheck';
 
-export function TabHider(props: { id: number; index: number; children: any }) {
-  // currently, we only render visible tabls
-  // alternatively, just hide invisible ones for less tab-switch latency but higher resource usage.
-  // alternatively, support disabling updates for all child components somehow.
-  const visible = props.index === props.id;
-  return visible ? props.children : <></>;
+export function TabHider(props: {
+  id: number;
+  index: number;
+  render: (hidden: boolean) => ReactElement;
+}) {
+  const hidden = props.index !== props.id;
+  const tabContent = props.render(hidden);
+  return (
+    <div style={{ display: hidden ? 'none' : undefined }}>{tabContent}</div>
+  );
 }
 
 export function PauseButton() {
@@ -151,15 +155,28 @@ export default function Detail() {
 
   const content = (
     <>
-      <TabHider id={0} index={tabIndex}>
-        <VizTab namespace={namespace} />
-      </TabHider>
-      <TabHider id={1} index={tabIndex}>
-        <ImageryTab namespace={namespace} />
-      </TabHider>
-      <TabHider id={2} index={tabIndex}>
-        <StatsTab namespace={namespace} />
-      </TabHider>
+      <TabHider
+        key={0}
+        id={0}
+        index={tabIndex}
+        render={(hidden) => <VizTab namespace={namespace} enabled={!hidden} />}
+      />
+      <TabHider
+        key={1}
+        id={1}
+        index={tabIndex}
+        render={(hidden) => (
+          <ImageryTab namespace={namespace} enabled={!hidden} />
+        )}
+      />
+      <TabHider
+        key={2}
+        id={2}
+        index={tabIndex}
+        render={(hidden) => (
+          <StatsTab namespace={namespace} enabled={!hidden} />
+        )}
+      />
     </>
   );
 

--- a/src/Detail.tsx
+++ b/src/Detail.tsx
@@ -122,11 +122,11 @@ export default function Detail() {
           style={{ transitionDelay: isLoading ? '500ms' : '0ms' }}
           unmountOnExit
         >
-          <Backdrop open={true}>
+          <Backdrop invisible open>
             <CircularProgress />
           </Backdrop>
         </Fade>
-        <Backdrop open={authorized === false}>
+        <Backdrop invisible open={authorized === false}>
           <Box maxWidth="40em">
             <Alert severity="error">
               <AlertTitle>Not authorized</AlertTitle>

--- a/src/ImageryTab.tsx
+++ b/src/ImageryTab.tsx
@@ -10,6 +10,7 @@ import {
   IconButton,
   Typography,
   useMediaQuery,
+  CardMedia,
 } from '@material-ui/core';
 import { Close } from '@material-ui/icons';
 import React, { useState, useCallback } from 'react';
@@ -100,9 +101,14 @@ export function ImageCard(props: {
   const card = (
     <Card style={{ maxWidth: '350px' }}>
       <CardActionArea onClick={handleOpen}>
+        <CardMedia>
+          {imageViewerContent(
+            enabled && (props.enablePreviews ?? false),
+            false
+          )}
+        </CardMedia>
         <CardContent>
-          {imageViewerContent(enabled && (props.enablePreviews ?? false), false)}
-          <Typography variant="body2" color="textSecondary" component="p">
+          <Typography variant="body2" component="p">
             {props.topic}
           </Typography>
         </CardContent>
@@ -135,7 +141,7 @@ export default function ImageryTab(props: {
   const compressedImageTopicCallback: RobofleetMsgListener = useCallback(
     (buf, match) => {
       (async () => {
-        const topic = match[0];
+        const topic = match[1];
 
         setObservedImages({
           ...observedImages,
@@ -152,7 +158,7 @@ export default function ImageryTab(props: {
   const pointcloudTopicCallback: RobofleetMsgListener = useCallback(
     (buf, match) => {
       (async () => {
-        const topic = match[0];
+        const topic = match[1];
 
         setObservedImages({
           ...observedImages,
@@ -167,12 +173,12 @@ export default function ImageryTab(props: {
   );
 
   useRobofleetMsgListener(
-    matchTopic(props.namespace, 'image_compressed/.+'),
+    matchTopic(props.namespace, '(image_compressed/.+)'),
     compressedImageTopicCallback
   );
 
   useRobofleetMsgListener(
-    matchTopic(props.namespace, 'pointcloud'),
+    matchTopic(props.namespace, '(pointcloud)'),
     pointcloudTopicCallback
   );
 
@@ -210,6 +216,7 @@ export default function ImageryTab(props: {
         flexDirection="row"
         flexWrap="wrap"
         justifyContent="space-around"
+        alignItems="start"
       >
         {imageContent}
       </Box>

--- a/src/ImageryTab.tsx
+++ b/src/ImageryTab.tsx
@@ -26,6 +26,7 @@ enum ImageType {
 }
 
 export function ImageCard(props: {
+  enabled: boolean;
   namespace: string;
   topic: string;
   data: flatbuffers.ByteBuffer;
@@ -34,6 +35,7 @@ export function ImageCard(props: {
   onClose?: () => void;
   onOpen?: () => void;
 }) {
+  const { enabled } = props;
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const smallWidth = useMediaQuery('(max-width: 800px)');
@@ -90,7 +92,7 @@ export function ImageCard(props: {
         </IconButton>
       </DialogTitle>
       <DialogContent dividers>
-        {imageViewerContent(dialogOpen, true)}
+        {imageViewerContent(enabled && dialogOpen, true)}
       </DialogContent>
     </Dialog>
   );
@@ -99,7 +101,7 @@ export function ImageCard(props: {
     <Card style={{ maxWidth: '350px' }}>
       <CardActionArea onClick={handleOpen}>
         <CardContent>
-          {imageViewerContent(props.enablePreviews ?? false, false)}
+          {imageViewerContent(enabled && (props.enablePreviews ?? false), false)}
           <Typography variant="body2" color="textSecondary" component="p">
             {props.topic}
           </Typography>
@@ -116,7 +118,11 @@ export function ImageCard(props: {
   );
 }
 
-export default function ImageryTab(props: { namespace: string }) {
+export default function ImageryTab(props: {
+  enabled: boolean;
+  namespace: string;
+}) {
+  const { enabled } = props;
   const [enablePreviews, setEnablePreviews] = useState(true);
   interface ImageMap {
     [topic: string]: {
@@ -180,6 +186,7 @@ export default function ImageryTab(props: { namespace: string }) {
       const { type, data } = observedImages[topic];
       return (
         <ImageCard
+          enabled={enabled}
           namespace={props.namespace}
           topic={topic}
           key={topic}

--- a/src/Overview.tsx
+++ b/src/Overview.tsx
@@ -159,7 +159,7 @@ export default function Overview() {
         <TableCell style={{ width: '3em' }} align="center">
           OK
         </TableCell>
-        <TableCell style={{ width: '5em' }} align="center">
+        <TableCell style={{ width: '6.5em' }} align="center">
           Battery
         </TableCell>
         <TableCell align="center">Status</TableCell>
@@ -185,20 +185,17 @@ export default function Overview() {
       batteryContent = 'unknown';
     }
 
-    const nameContent = obj.is_active ? (
+    const nameContent = (
       <Button
         component={Link}
         to={`/robot/${btoa(name)}`}
         style={{ textTransform: 'none' }}
-        variant="outlined"
+        variant={obj.is_active ? 'outlined' : 'text'}
         disabled={!obj.is_active}
+        startIcon={!obj.is_active && <CloudOff />}
       >
         {name}
       </Button>
-    ) : (
-      <Typography variant="button" style={{ textTransform: 'none' }}>
-        {name} (Offline)
-      </Typography>
     );
 
     return (

--- a/src/Overview.tsx
+++ b/src/Overview.tsx
@@ -231,7 +231,7 @@ export default function Overview() {
           Robots
         </Typography>
         <TableContainer component={Paper}>
-          <Table size="small">
+          <Table>
             {tableHead}
             <TableBody>{items}</TableBody>
           </Table>

--- a/src/Overview.tsx
+++ b/src/Overview.tsx
@@ -20,6 +20,7 @@ import React, {
   useContext,
   useEffect,
   useState,
+  useMemo,
   ReactElement,
 } from 'react';
 import { Link } from 'react-router-dom';
@@ -144,7 +145,15 @@ export default function Overview() {
     })();
   }, []);
 
-  const items = Object.entries(data).map(([name, obj]) => {
+  const sortedData = useMemo(
+    () =>
+      Object.entries(data).sort(
+        ([_, a], [__, b]) => Number(b.is_active) - Number(a.is_active)
+      ),
+    [data]
+  );
+
+  const items = sortedData.map(([name, obj]) => {
     let batteryContent: ReactElement | string;
     if (obj.battery_level >= 0) {
       batteryContent = <PercentageDisplay value={obj.battery_level} />;

--- a/src/Overview.tsx
+++ b/src/Overview.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  CircularProgress,
   Container,
   Paper,
   Table,
@@ -229,18 +228,6 @@ export default function Overview() {
             </TableHead>
             <TableBody>{items}</TableBody>
           </Table>
-          <div
-            style={{ padding: '1em', display: 'flex', alignItems: 'center' }}
-          >
-            <CircularProgress variant="indeterminate" disableShrink size={16} />
-            <Typography
-              variant="body2"
-              color="textSecondary"
-              style={{ marginLeft: '1em' }}
-            >
-              Watching for new robots
-            </Typography>
-          </div>
         </TableContainer>
       </Container>
     </>

--- a/src/Overview.tsx
+++ b/src/Overview.tsx
@@ -9,12 +9,13 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
   makeStyles,
   Theme,
 } from '@material-ui/core';
 import { Check, Clear } from '@material-ui/icons';
-import SyncDisabled from '@material-ui/icons/SyncDisabled';
+import CloudOff from '@material-ui/icons/CloudOff';
 import React, {
   useCallback,
   useContext,
@@ -65,17 +66,23 @@ const MaybeDisconnectedLabel = (props: {
   label: ReactElement | string;
   disconnected: boolean;
 }) => {
-  return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      alignItems="center"
-      justifyContent="center"
-    >
-      {props.disconnected && <SyncDisabled fontSize="small" />}
-      <div>{props.label}</div>
-    </Box>
-  );
+  if (props.disconnected) {
+    return (
+      <Tooltip arrow title="Offline, showing saved data.">
+        <Box
+          display="flex"
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <CloudOff fontSize="small" />
+          <Box marginRight={1} />
+          {props.label}
+        </Box>
+      </Tooltip>
+    );
+  }
+  return <>{props.label}</>;
 };
 
 export default function Overview() {

--- a/src/Overview.tsx
+++ b/src/Overview.tsx
@@ -145,6 +145,23 @@ export default function Overview() {
     })();
   }, []);
 
+  const tableHead = (
+    <TableHead>
+      <TableRow>
+        <TableCell align="left">Name</TableCell>
+        <TableCell style={{ width: '3em' }} align="center">
+          OK
+        </TableCell>
+        <TableCell style={{ width: '5em' }} align="center">
+          Battery
+        </TableCell>
+        <TableCell align="center">Status</TableCell>
+        <TableCell align="center">Location</TableCell>
+        <TableCell align="center">Last seen</TableCell>
+      </TableRow>
+    </TableHead>
+  );
+
   const sortedData = useMemo(
     () =>
       Object.entries(data).sort(
@@ -215,20 +232,7 @@ export default function Overview() {
         </Typography>
         <TableContainer component={Paper}>
           <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell align="left">Name</TableCell>
-                <TableCell style={{ width: '3em' }} align="center">
-                  OK
-                </TableCell>
-                <TableCell style={{ width: '5em' }} align="center">
-                  Battery
-                </TableCell>
-                <TableCell align="center">Status</TableCell>
-                <TableCell align="center">Location</TableCell>
-                <TableCell align="center">Last seen</TableCell>
-              </TableRow>
-            </TableHead>
+            {tableHead}
             <TableBody>{items}</TableBody>
           </Table>
         </TableContainer>

--- a/src/StatsTab.tsx
+++ b/src/StatsTab.tsx
@@ -2,7 +2,10 @@ import { Box, Card, CardContent, Container } from '@material-ui/core';
 import React from 'react';
 import OdometryViewer from './components/OdometryViewer';
 
-export default function StatsTab(props: any) {
+export default function StatsTab(props: {
+  namespace: string;
+  enabled: boolean;
+}) {
   return (
     <Container maxWidth="md">
       <Box height="2em" />

--- a/src/VizTab.tsx
+++ b/src/VizTab.tsx
@@ -169,8 +169,9 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-export default function VizTab(props: { namespace: string }) {
+export default function VizTab(props: { namespace: string; enabled: boolean }) {
   type ClickAction = 'Default' | 'Localize' | 'SetNav';
+  const { enabled } = props;
 
   const ws = useContext(WebSocketContext);
   const classes = useStyles();
@@ -210,7 +211,8 @@ export default function VizTab(props: { namespace: string }) {
         setLocAlertOpen(false);
       },
       [mapName]
-    )
+    ),
+    { enabled }
   );
 
   // Loading map names
@@ -354,6 +356,7 @@ export default function VizTab(props: { namespace: string }) {
         navGraphVisible={locShowNavMap}
       />
       <LaserScanViewer
+        enabled={enabled}
         namespace={props.namespace}
         topic="velodyne_2dscan"
         matrix={baseLink}
@@ -361,6 +364,7 @@ export default function VizTab(props: { namespace: string }) {
         visible={scanShow}
       />
       <VisualizationViewer
+        enabled={enabled}
         namespace={props.namespace}
         topic="visualization"
         baseLinkMatrix={baseLink}

--- a/src/components/LaserScanViewer.tsx
+++ b/src/components/LaserScanViewer.tsx
@@ -5,6 +5,7 @@ import { fb } from '../schema';
 import { matchTopic } from '../util';
 
 export default function LaserScanViewer(props: {
+  enabled: boolean;
   namespace: string;
   topic: string;
   color: any;
@@ -12,6 +13,7 @@ export default function LaserScanViewer(props: {
   pointSize?: number;
   visible?: boolean;
 }) {
+  const { enabled } = props;
   const [pointsData, setPointsData] = useState(new Float32Array(0));
 
   useRobofleetMsgListener(
@@ -29,7 +31,8 @@ export default function LaserScanViewer(props: {
         posData[idx + 2] = 0;
       }
       setPointsData(posData);
-    }, [])
+    }, []),
+    { enabled }
   );
 
   const pointsPosAttrib = useMemo(

--- a/src/components/OdometryViewer.tsx
+++ b/src/components/OdometryViewer.tsx
@@ -4,8 +4,11 @@ import { fb } from '../schema';
 import { matchTopic } from '../util';
 import useRobofleetMsgListener from '../hooks/useRobofleetMsgListener';
 
-export default function OdometryViewer(props: { namespace: string }) {
-  const { namespace } = props;
+export default function OdometryViewer(props: {
+  namespace: string;
+  enabled: boolean;
+}) {
+  const { namespace, enabled } = props;
   const [loaded, setLoaded] = useState(false);
   const [pos, setPos] = useState([0, 0, 0]);
   const [vel, setVel] = useState([0, 0, 0]);
@@ -25,7 +28,8 @@ export default function OdometryViewer(props: { namespace: string }) {
         odom.twist()?.twist()?.linear()?.y() ?? 0,
         odom.twist()?.twist()?.linear()?.z() ?? 0,
       ]);
-    }, [])
+    }, []),
+    { enabled }
   );
 
   const positionDisplay = (

--- a/src/components/PercentageDisplay.tsx
+++ b/src/components/PercentageDisplay.tsx
@@ -1,53 +1,48 @@
 import Box from '@material-ui/core/Box';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import LinearProgress from '@material-ui/core/LinearProgress';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import PropTypes from 'prop-types';
 import React from 'react';
 
+const barColor = (value: number, opacity: number) => {
+  const f = Math.round(value * 255);
+  return `rgba(${255 - f}, ${f}, 0, ${opacity})`;
+};
+
 const useStyles = makeStyles({
-  root: (props: { value: number }) => {
-    const f = Math.round(props.value * 255);
+  root: () => {
     return {
-      color: `rgba(${255 - f}, ${f}, 50, 0.5)`,
+      height: 8,
     };
   },
+  colorPrimary: (props: { value: number }) => ({
+    backgroundColor: barColor(props.value, 0.2),
+  }),
+  barColorPrimary: (props: { value: number }) => ({
+    backgroundColor: barColor(props.value, 1.0),
+  }),
 });
 
 export default function PercentageDisplay(props: { value: number }) {
   const classes = useStyles({ value: props.value });
+  const { value: originalValue, ...otherProps } = props;
+  const value = originalValue * 100;
 
   return (
-    <Box position="relative" display="inline-flex">
-      <CircularProgress
-        variant="static"
-        className={classes.root}
-        value={props.value * 100}
-      />
-      <Box
-        top={0}
-        left={0}
-        bottom={0}
-        right={0}
-        position="absolute"
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-      >
-        <Typography
-          variant="caption"
-          component="div"
-          color="textSecondary"
-        >{`${Math.round(props.value * 100)}%`}</Typography>
+    <Box display="flex" alignItems="center">
+      <Box width="100%" mr={0.5}>
+        <LinearProgress
+          classes={classes}
+          variant="determinate"
+          value={value}
+          {...otherProps}
+        />
+      </Box>
+      <Box minWidth={35}>
+        <Typography variant="body2" color="textPrimary">{`${Math.round(
+          value
+        )}%`}</Typography>
       </Box>
     </Box>
   );
 }
-
-PercentageDisplay.propTypes = {
-  /**
-   * The value of the progress indicator for the determinate and static variants.
-   * Value between 0 and 100.
-   */
-  value: PropTypes.number.isRequired,
-};

--- a/src/components/PointCloudViewer.tsx
+++ b/src/components/PointCloudViewer.tsx
@@ -144,9 +144,7 @@ export default function PointCloudViewer(props: {
   }, [point_cloud_scale]);
 
   return (
-    <Canvas
-      style={{ height: large ? 600 : '100%', width: large ? 960 : '100%' }}
-    >
+    <Canvas style={{ height: large ? 600 : 200, width: large ? 960 : 320 }}>
       <points
         frustumCulled={false}
         matrixAutoUpdate={false}

--- a/src/components/VisualizationViewer.tsx
+++ b/src/components/VisualizationViewer.tsx
@@ -7,13 +7,14 @@ import ColoredLinesViewer from './ColoredLinesViewer';
 import ColoredPointsViewer from './ColoredPointsViewer';
 
 export default function VisualizationViewer(props: {
+  enabled: boolean;
   namespace: string;
   topic: string;
   baseLinkMatrix: Matrix4;
   pointsVisible?: boolean;
   linesVisible?: boolean;
 }) {
-  const { namespace, topic, baseLinkMatrix } = props;
+  const { enabled, namespace, topic, baseLinkMatrix } = props;
   const [mapMsg, setMapMsg] = useState<fb.amrl_msgs.VisualizationMsg | null>(
     null
   );
@@ -33,7 +34,8 @@ export default function VisualizationViewer(props: {
       if (frame === 'base_link') {
         setBaseLinkMsg(msg);
       }
-    }, [])
+    }, []),
+    { enabled }
   );
 
   return (

--- a/src/hooks/useRobofleetSubscription.ts
+++ b/src/hooks/useRobofleetSubscription.ts
@@ -1,5 +1,5 @@
 import { flatbuffers } from 'flatbuffers';
-import { useContext, useEffect, useState, useCallback } from 'react';
+import { useContext, useEffect, useCallback } from 'react';
 import WebSocketContext from '../contexts/WebSocketContext';
 import { fb } from '../schema';
 
@@ -49,7 +49,6 @@ export default function useRobofleetSubscription(
   topicRegex: RegExp,
   { enabled = true }: { enabled?: boolean } = {}
 ) {
-  const [shouldBeSubscribed, setShouldBeSubscribed] = useState(enabled);
   const ws = useContext(WebSocketContext);
   if (ws === null) {
     throw new Error('No WebSocketContext provided.');
@@ -78,20 +77,9 @@ export default function useRobofleetSubscription(
   // subscribe if should be subscribed, unsubscribe on cleanup if subscribed.
   useEffect(() => {
     if (!ws.connected) return;
-
-    if (shouldBeSubscribed) subscribe();
-    else unsubscribe();
-
-    if (shouldBeSubscribed) return () => unsubscribe();
-  }, [shouldBeSubscribed, ws.connected, subscribe, unsubscribe]);
-
-  // unsubscribe on disable
-  useEffect(() => {
-    if (!enabled) setShouldBeSubscribed(false);
-  }, [enabled]);
-
-  // subscribe if enabled
-  useEffect(() => {
-    if (enabled) setShouldBeSubscribed(true);
-  }, [enabled]);
+    if (enabled) {
+      subscribe();
+      return () => unsubscribe();
+    }
+  }, [enabled, ws.connected, subscribe, unsubscribe]);
 }


### PR DESCRIPTION
Various improvements to UI:

* Overview (robots table):
  * slightly less dense with less visual noise
  * online robots above offline robots
  * robot name is now a button to open details page (no longer need to scroll table on mobile)
  * remove "watching for robots"

Before | After
--- | ---
![overview_before](https://user-images.githubusercontent.com/3401573/99171324-a5fe7500-26cd-11eb-9b46-3871ec4d008f.png) | ![overview_after](https://user-images.githubusercontent.com/3401573/99171327-a860cf00-26cd-11eb-8c98-ee8d0e0b1e64.png)


* Detail view:
  * faster tab switching
    * also preserves tab state
  * less screen flashing (authorization, waiting for data) when opening detail view
  * more readable auth failure notice
  * each tab now has its own URL