### PR TITLE
Add 3d point cloud vis to image tab

### DIFF
--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { fb } from '../schema';
 
 export default function CompressedImageViewer(props: {
-  image: ImageBitmap;
+  data: flatbuffers.ByteBuffer;
   enabled: boolean;
 }) {
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -13,10 +14,19 @@ export default function CompressedImageViewer(props: {
       if (canvas.current === null) return;
       const ctx = canvas.current.getContext('2d');
       if (ctx === null) return;
-      if (size[0] !== props.image.width || size[1] !== props.image.height)
-        setSize([props.image.width, props.image.height]);
+
+      const ci = fb.sensor_msgs.CompressedImage.getRootAsCompressedImage(
+        props.data
+      );
+      const blob = new Blob([ci.dataArray() ?? new Uint8Array()], {
+        type: `image/${ci.format()}`,
+      });
+      const bmp = await window.createImageBitmap(blob);
+      if (size[0] !== bmp.width || size[1] !== bmp.height)
+        setSize([bmp.width, bmp.height]);
+
       ctx.clearRect(0, 0, size[0], size[1]);
-      ctx.drawImage(props.image, 0, 0);
+      ctx.drawImage(bmp, 0, 0);
     })();
   });
 

--- a/src/components/PointCloudViewer.tsx
+++ b/src/components/PointCloudViewer.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas } from 'react-three-fiber';
+import { Matrix4, Vector3 } from 'three';
+import { fb } from '../schema';
+
+const getFloatFromDataArray = (
+  arr: Uint8Array,
+  start: number,
+  end: number,
+  little_endian: boolean
+) => {
+  let view = new DataView(arr.slice(start, end).buffer);
+
+  return view.getFloat32(0, little_endian);
+};
+
+export default function PointCloudViewer(props: {
+  data: flatbuffers.ByteBuffer;
+  enabled: boolean;
+  point_skip_ratio: number;
+  point_cloud_scale: number;
+  max_intensity: number;
+  large: boolean;
+}) {
+  const {
+    point_skip_ratio,
+    point_cloud_scale,
+    max_intensity,
+    data,
+    large,
+  } = props;
+  const [pointData, setPointData] = useState(new Float32Array(0));
+  const [pointIntensityData, setPointIntensityData] = useState(
+    new Float32Array(0)
+  );
+
+  useEffect(() => {
+    const cloud = fb.sensor_msgs.PointCloud2.getRootAsPointCloud2(data);
+
+    // Identify the x, y, z fields from the cloud
+    let xOffset: number | undefined;
+    let yOffset: number | undefined;
+    let zOffset: number | undefined;
+    let intensityOffset: number | undefined;
+
+    for (let i = 0; i < cloud.fieldsLength(); i++) {
+      if (cloud.fields(i)?.name() === 'x') {
+        xOffset = cloud.fields(i)?.offset();
+      } else if (cloud.fields(i)?.name() === 'y') {
+        yOffset = cloud.fields(i)?.offset();
+      } else if (cloud.fields(i)?.name() === 'z') {
+        zOffset = cloud.fields(i)?.offset();
+      } else if (cloud.fields(i)?.name() === 'intensity') {
+        intensityOffset = cloud.fields(i)?.offset();
+      }
+    }
+
+    if (
+      xOffset === undefined ||
+      yOffset === undefined ||
+      zOffset === undefined
+    ) {
+      console.warn('Unable to find required fields in point cloud data.');
+      return;
+    }
+
+    const step = cloud.pointStep();
+    let num_points = cloud.dataLength() / cloud.pointStep();
+    num_points = num_points / point_skip_ratio;
+    const points = new Float32Array(num_points * 3);
+    const pointIntensity = new Float32Array(num_points * 3);
+
+    for (let i = 0; i < num_points; i += point_skip_ratio) {
+      const cloud_idx = i * step;
+      const point_idx = i * 3;
+
+      // assume fields are of length 4, and are float datatype
+      points[point_idx + 0] = getFloatFromDataArray(
+        cloud.dataArray()!,
+        cloud_idx + xOffset,
+        cloud_idx + xOffset + 4,
+        !cloud.isBigendian()
+      );
+      points[point_idx + 1] = getFloatFromDataArray(
+        cloud.dataArray()!,
+        cloud_idx + yOffset,
+        cloud_idx + yOffset + 4,
+        !cloud.isBigendian()
+      );
+      points[point_idx + 2] = getFloatFromDataArray(
+        cloud.dataArray()!,
+        cloud_idx + zOffset,
+        cloud_idx + zOffset + 4,
+        !cloud.isBigendian()
+      );
+      if (intensityOffset) {
+        pointIntensity[point_idx + 0] = 0.75;
+        pointIntensity[point_idx + 1] = 0.75;
+        pointIntensity[point_idx + 2] =
+          getFloatFromDataArray(
+            cloud.dataArray()!,
+            cloud_idx + intensityOffset,
+            cloud_idx + intensityOffset + 4,
+            !cloud.isBigendian()
+          ) / max_intensity;
+      }
+    }
+    setPointData(points);
+    setPointIntensityData(pointIntensity);
+  }, [max_intensity, point_skip_ratio, data]);
+
+  const pointsPosAttrib = useMemo(
+    () => (
+      <bufferAttribute
+        attachObject={['attributes', 'position']}
+        // can't use props; need to reconstruct to resize buffer
+        args={[pointData, 3, false]}
+        count={pointData.length / 3}
+        onUpdate={(self) => {
+          self.needsUpdate = true;
+        }}
+      />
+    ),
+    [pointData]
+  );
+
+  const pointsColorAttrib = useMemo(
+    () => (
+      <bufferAttribute
+        attachObject={['attributes', 'color']}
+        // can't use props; need to reconstruct to resize buffer
+        args={[pointIntensityData, 3, false]}
+        count={pointIntensityData.length / 3}
+        onUpdate={(self) => {
+          self.needsUpdate = true;
+        }}
+      />
+    ),
+    [pointIntensityData]
+  );
+
+  const T = useMemo(() => {
+    const rot = new Matrix4().makeRotationAxis(
+      new Vector3(1, 0, 0),
+      -Math.PI / 3
+    );
+    return rot.multiplyScalar(point_cloud_scale);
+  }, [point_cloud_scale]);
+
+  return (
+    <Canvas
+      style={{ height: large ? 600 : '100%', width: large ? 960 : '100%' }}
+    >
+      <points
+        frustumCulled={false}
+        matrixAutoUpdate={false}
+        matrixWorldNeedsUpdate={true}
+        matrix={T}
+        visible={true}
+      >
+        <bufferGeometry attach="geometry">
+          {pointsPosAttrib}
+          {pointsColorAttrib}
+        </bufferGeometry>
+        <pointsMaterial
+          attach="material"
+          vertexColors={true}
+          size={0.25}
+          sizeAttenuation={false}
+        />
+      </points>
+    </Canvas>
+  );
+}

--- a/src/components/PointCloudViewer.tsx
+++ b/src/components/PointCloudViewer.tsx
@@ -140,9 +140,12 @@ export default function PointCloudViewer(props: {
   );
 
   const T = useMemo(() => {
-    const rot = new Matrix4().makeRotationAxis(
+    let rot = new Matrix4().makeRotationAxis(
       new Vector3(1, 0, 0),
       -Math.PI / 3
+    );
+    rot = rot.multiply(
+      new Matrix4().makeRotationAxis(new Vector3(0, 0, 1), Math.PI / 2)
     );
     return rot.multiplyScalar(point_cloud_scale);
   }, [point_cloud_scale]);

--- a/src/schema_generated.ts
+++ b/src/schema_generated.ts
@@ -127,6 +127,78 @@ export namespace fb.sensor_msgs.NavSatFixConstants {
 }
 
 /**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum int8 {
+    value = 1,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum uint8 {
+    value = 2,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum int16 {
+    value = 3,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum uint16 {
+    value = 4,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum int32 {
+    value = 5,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum uint32 {
+    value = 6,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum float32 {
+    value = 7,
+  }
+}
+
+/**
+ * @enum {number}
+ */
+export namespace fb.sensor_msgs.PointFieldConstants {
+  export enum float64 {
+    value = 8,
+  }
+}
+
+/**
  * @constructor
  */
 export namespace fb {
@@ -3529,6 +3601,536 @@ export namespace fb.sensor_msgs {
       builder.requiredField(offset, 6); // header
       builder.requiredField(offset, 8); // format
       builder.requiredField(offset, 10); // data
+      return offset;
+    }
+  }
+}
+/**
+ * @constructor
+ */
+export namespace fb.sensor_msgs {
+  export class PointField {
+    bb: flatbuffers.ByteBuffer | null = null;
+
+    bb_pos: number = 0;
+    /**
+     * @param number i
+     * @param flatbuffers.ByteBuffer bb
+     * @returns PointField
+     */
+    __init(i: number, bb: flatbuffers.ByteBuffer): PointField {
+      this.bb_pos = i;
+      this.bb = bb;
+      return this;
+    }
+
+    /**
+     * @param flatbuffers.ByteBuffer bb
+     * @param PointField= obj
+     * @returns PointField
+     */
+    static getRootAsPointField(
+      bb: flatbuffers.ByteBuffer,
+      obj?: PointField
+    ): PointField {
+      return (obj || new PointField()).__init(
+        bb.readInt32(bb.position()) + bb.position(),
+        bb
+      );
+    }
+
+    /**
+     * @param flatbuffers.ByteBuffer bb
+     * @param PointField= obj
+     * @returns PointField
+     */
+    static getSizePrefixedRootAsPointField(
+      bb: flatbuffers.ByteBuffer,
+      obj?: PointField
+    ): PointField {
+      bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+      return (obj || new PointField()).__init(
+        bb.readInt32(bb.position()) + bb.position(),
+        bb
+      );
+    }
+
+    /**
+     * @param fb.MsgMetadata= obj
+     * @returns fb.MsgMetadata|null
+     */
+    _metadata(obj?: fb.MsgMetadata): fb.MsgMetadata | null {
+      var offset = this.bb!.__offset(this.bb_pos, 4);
+      return offset
+        ? (obj || new fb.MsgMetadata()).__init(
+            this.bb!.__indirect(this.bb_pos + offset),
+            this.bb!
+          )
+        : null;
+    }
+
+    /**
+     * @param flatbuffers.Encoding= optionalEncoding
+     * @returns string|Uint8Array|null
+     */
+    name(): string | null;
+    name(optionalEncoding: flatbuffers.Encoding): string | Uint8Array | null;
+    name(optionalEncoding?: any): string | Uint8Array | null {
+      var offset = this.bb!.__offset(this.bb_pos, 6);
+      return offset
+        ? this.bb!.__string(this.bb_pos + offset, optionalEncoding)
+        : null;
+    }
+
+    /**
+     * @returns number
+     */
+    offset(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 8);
+      return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @returns number
+     */
+    datatype(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 10);
+      return offset ? this.bb!.readUint8(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @returns number
+     */
+    count(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 12);
+      return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     */
+    static startPointField(builder: flatbuffers.Builder) {
+      builder.startObject(5);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param flatbuffers.Offset _metadataOffset
+     */
+    static add_Metadata(
+      builder: flatbuffers.Builder,
+      _metadataOffset: flatbuffers.Offset
+    ) {
+      builder.addFieldOffset(0, _metadataOffset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param flatbuffers.Offset nameOffset
+     */
+    static addName(
+      builder: flatbuffers.Builder,
+      nameOffset: flatbuffers.Offset
+    ) {
+      builder.addFieldOffset(1, nameOffset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number offset
+     */
+    static addOffset(builder: flatbuffers.Builder, offset: number) {
+      builder.addFieldInt32(2, offset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number datatype
+     */
+    static addDatatype(builder: flatbuffers.Builder, datatype: number) {
+      builder.addFieldInt8(3, datatype, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number count
+     */
+    static addCount(builder: flatbuffers.Builder, count: number) {
+      builder.addFieldInt32(4, count, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @returns flatbuffers.Offset
+     */
+    static endPointField(builder: flatbuffers.Builder): flatbuffers.Offset {
+      var offset = builder.endObject();
+      builder.requiredField(offset, 6); // name
+      return offset;
+    }
+
+    static createPointField(
+      builder: flatbuffers.Builder,
+      _metadataOffset: flatbuffers.Offset,
+      nameOffset: flatbuffers.Offset,
+      offset: number,
+      datatype: number,
+      count: number
+    ): flatbuffers.Offset {
+      PointField.startPointField(builder);
+      PointField.add_Metadata(builder, _metadataOffset);
+      PointField.addName(builder, nameOffset);
+      PointField.addOffset(builder, offset);
+      PointField.addDatatype(builder, datatype);
+      PointField.addCount(builder, count);
+      return PointField.endPointField(builder);
+    }
+  }
+}
+/**
+ * @constructor
+ */
+export namespace fb.sensor_msgs {
+  export class PointCloud2 {
+    bb: flatbuffers.ByteBuffer | null = null;
+
+    bb_pos: number = 0;
+    /**
+     * @param number i
+     * @param flatbuffers.ByteBuffer bb
+     * @returns PointCloud2
+     */
+    __init(i: number, bb: flatbuffers.ByteBuffer): PointCloud2 {
+      this.bb_pos = i;
+      this.bb = bb;
+      return this;
+    }
+
+    /**
+     * @param flatbuffers.ByteBuffer bb
+     * @param PointCloud2= obj
+     * @returns PointCloud2
+     */
+    static getRootAsPointCloud2(
+      bb: flatbuffers.ByteBuffer,
+      obj?: PointCloud2
+    ): PointCloud2 {
+      return (obj || new PointCloud2()).__init(
+        bb.readInt32(bb.position()) + bb.position(),
+        bb
+      );
+    }
+
+    /**
+     * @param flatbuffers.ByteBuffer bb
+     * @param PointCloud2= obj
+     * @returns PointCloud2
+     */
+    static getSizePrefixedRootAsPointCloud2(
+      bb: flatbuffers.ByteBuffer,
+      obj?: PointCloud2
+    ): PointCloud2 {
+      bb.setPosition(bb.position() + flatbuffers.SIZE_PREFIX_LENGTH);
+      return (obj || new PointCloud2()).__init(
+        bb.readInt32(bb.position()) + bb.position(),
+        bb
+      );
+    }
+
+    /**
+     * @param fb.MsgMetadata= obj
+     * @returns fb.MsgMetadata|null
+     */
+    _metadata(obj?: fb.MsgMetadata): fb.MsgMetadata | null {
+      var offset = this.bb!.__offset(this.bb_pos, 4);
+      return offset
+        ? (obj || new fb.MsgMetadata()).__init(
+            this.bb!.__indirect(this.bb_pos + offset),
+            this.bb!
+          )
+        : null;
+    }
+
+    /**
+     * @param fb.std_msgs.Header= obj
+     * @returns fb.std_msgs.Header|null
+     */
+    header(obj?: fb.std_msgs.Header): fb.std_msgs.Header | null {
+      var offset = this.bb!.__offset(this.bb_pos, 6);
+      return offset
+        ? (obj || new fb.std_msgs.Header()).__init(
+            this.bb!.__indirect(this.bb_pos + offset),
+            this.bb!
+          )
+        : null;
+    }
+
+    /**
+     * @returns number
+     */
+    height(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 8);
+      return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @returns number
+     */
+    width(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 10);
+      return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @param number index
+     * @param fb.sensor_msgs.PointField= obj
+     * @returns fb.sensor_msgs.PointField
+     */
+    fields(
+      index: number,
+      obj?: fb.sensor_msgs.PointField
+    ): fb.sensor_msgs.PointField | null {
+      var offset = this.bb!.__offset(this.bb_pos, 12);
+      return offset
+        ? (obj || new fb.sensor_msgs.PointField()).__init(
+            this.bb!.__indirect(
+              this.bb!.__vector(this.bb_pos + offset) + index * 4
+            ),
+            this.bb!
+          )
+        : null;
+    }
+
+    /**
+     * @returns number
+     */
+    fieldsLength(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 12);
+      return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @returns boolean
+     */
+    isBigendian(): boolean {
+      var offset = this.bb!.__offset(this.bb_pos, 14);
+      return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+    }
+
+    /**
+     * @returns number
+     */
+    pointStep(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 16);
+      return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @returns number
+     */
+    rowStep(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 18);
+      return offset ? this.bb!.readUint32(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @param number index
+     * @returns number
+     */
+    data(index: number): number | null {
+      var offset = this.bb!.__offset(this.bb_pos, 20);
+      return offset
+        ? this.bb!.readUint8(this.bb!.__vector(this.bb_pos + offset) + index)
+        : 0;
+    }
+
+    /**
+     * @returns number
+     */
+    dataLength(): number {
+      var offset = this.bb!.__offset(this.bb_pos, 20);
+      return offset ? this.bb!.__vector_len(this.bb_pos + offset) : 0;
+    }
+
+    /**
+     * @returns Uint8Array
+     */
+    dataArray(): Uint8Array | null {
+      var offset = this.bb!.__offset(this.bb_pos, 20);
+      return offset
+        ? new Uint8Array(
+            this.bb!.bytes().buffer,
+            this.bb!.bytes().byteOffset +
+              this.bb!.__vector(this.bb_pos + offset),
+            this.bb!.__vector_len(this.bb_pos + offset)
+          )
+        : null;
+    }
+
+    /**
+     * @returns boolean
+     */
+    isDense(): boolean {
+      var offset = this.bb!.__offset(this.bb_pos, 22);
+      return offset ? !!this.bb!.readInt8(this.bb_pos + offset) : false;
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     */
+    static startPointCloud2(builder: flatbuffers.Builder) {
+      builder.startObject(10);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param flatbuffers.Offset _metadataOffset
+     */
+    static add_Metadata(
+      builder: flatbuffers.Builder,
+      _metadataOffset: flatbuffers.Offset
+    ) {
+      builder.addFieldOffset(0, _metadataOffset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param flatbuffers.Offset headerOffset
+     */
+    static addHeader(
+      builder: flatbuffers.Builder,
+      headerOffset: flatbuffers.Offset
+    ) {
+      builder.addFieldOffset(1, headerOffset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number height
+     */
+    static addHeight(builder: flatbuffers.Builder, height: number) {
+      builder.addFieldInt32(2, height, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number width
+     */
+    static addWidth(builder: flatbuffers.Builder, width: number) {
+      builder.addFieldInt32(3, width, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param flatbuffers.Offset fieldsOffset
+     */
+    static addFields(
+      builder: flatbuffers.Builder,
+      fieldsOffset: flatbuffers.Offset
+    ) {
+      builder.addFieldOffset(4, fieldsOffset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param Array.<flatbuffers.Offset> data
+     * @returns flatbuffers.Offset
+     */
+    static createFieldsVector(
+      builder: flatbuffers.Builder,
+      data: flatbuffers.Offset[]
+    ): flatbuffers.Offset {
+      builder.startVector(4, data.length, 4);
+      for (var i = data.length - 1; i >= 0; i--) {
+        builder.addOffset(data[i]);
+      }
+      return builder.endVector();
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number numElems
+     */
+    static startFieldsVector(builder: flatbuffers.Builder, numElems: number) {
+      builder.startVector(4, numElems, 4);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param boolean isBigendian
+     */
+    static addIsBigendian(builder: flatbuffers.Builder, isBigendian: boolean) {
+      builder.addFieldInt8(5, +isBigendian, +false);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number pointStep
+     */
+    static addPointStep(builder: flatbuffers.Builder, pointStep: number) {
+      builder.addFieldInt32(6, pointStep, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number rowStep
+     */
+    static addRowStep(builder: flatbuffers.Builder, rowStep: number) {
+      builder.addFieldInt32(7, rowStep, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param flatbuffers.Offset dataOffset
+     */
+    static addData(
+      builder: flatbuffers.Builder,
+      dataOffset: flatbuffers.Offset
+    ) {
+      builder.addFieldOffset(8, dataOffset, 0);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param Array.<number> data
+     * @returns flatbuffers.Offset
+     */
+    static createDataVector(
+      builder: flatbuffers.Builder,
+      data: number[] | Uint8Array
+    ): flatbuffers.Offset {
+      builder.startVector(1, data.length, 1);
+      for (var i = data.length - 1; i >= 0; i--) {
+        builder.addInt8(data[i]);
+      }
+      return builder.endVector();
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param number numElems
+     */
+    static startDataVector(builder: flatbuffers.Builder, numElems: number) {
+      builder.startVector(1, numElems, 1);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @param boolean isDense
+     */
+    static addIsDense(builder: flatbuffers.Builder, isDense: boolean) {
+      builder.addFieldInt8(9, +isDense, +false);
+    }
+
+    /**
+     * @param flatbuffers.Builder builder
+     * @returns flatbuffers.Offset
+     */
+    static endPointCloud2(builder: flatbuffers.Builder): flatbuffers.Offset {
+      var offset = builder.endObject();
+      builder.requiredField(offset, 6); // header
+      builder.requiredField(offset, 12); // fields
+      builder.requiredField(offset, 20); // data
       return offset;
     }
   }


### PR DESCRIPTION
Adds a new image card type for showing point clouds, and moves some of the image processing stuff down into the individual "viewers"
Eventually we want this kind of pattern to support non-compressed-image messages, so I think the structural changes in this code are generally positive, even if we eventually move the 3d point cloud vis itself into the Localization tab.
For now, it's nice to check in the code for processing the point cloud on the JS side since it was tricky to do correctly and I don't want to lose it